### PR TITLE
Improve warning variety

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -11,6 +11,7 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
+  justify-content: center;
 
   height: 100%;
   width: 100%;
@@ -33,13 +34,17 @@
   display: flex;
   margin: 10px;
 }
+
 .card {
+  display: flex;
   flex: 0 0 calc(50% - 20px);
   max-width: calc(50% - 20px);
+  justify-content: center;
   padding: 10px;
+  align-items: center;
 }
 
-@media (max-width: 700px) {
+@media (max-width: 1000px) {
   .card {
     flex: 0 0 calc(100% - 10px);
     /* One card per row with a small gap between them */

--- a/src/app/display/display.component.css
+++ b/src/app/display/display.component.css
@@ -7,7 +7,6 @@ pre::first-line {
 }
 
 .card {
-  max-width: 1000px;
   width: 100%;
   height: 100%;
   padding: 5px;

--- a/src/app/editor-setting/editor-setting.dialog.css
+++ b/src/app/editor-setting/editor-setting.dialog.css
@@ -23,17 +23,22 @@
 .label-group {
   display: flex;
   align-items: center;
+  justify-content: lef;
   margin-top: 10px;
 }
 
 .label {
-  width: 100px;
-  font: 0.8em sans-serif;
+  width: 20%;
+    font: 0.9em sans-serif;
   text-align: right;
   margin-right: 10px;
 }
 
-span {
+.label-item {
+  width: 80%;
+}
+
+.label-title {
   font-weight: bold;
 }
 

--- a/src/app/editor-setting/editor-setting.dialog.html
+++ b/src/app/editor-setting/editor-setting.dialog.html
@@ -1,30 +1,48 @@
 <h2 mat-dialog-title>Settings</h2>
-<div mat-dialog-content>
-
+<div mat-dialog-content class="mat-typography">
   <div class="label-group">
-    <div class="label"><span>Remove double spacing</span></div>
-    <mat-slide-toggle [(ngModel)]="data.removeDoubleSpace" (change)="emitData()"></mat-slide-toggle>
+    <div class="label"><span class="label-title">Remove double spacing</span></div>
+    <mat-slide-toggle class="label-item" [(ngModel)]="data.removeDoubleSpace" (change)="emitData()"></mat-slide-toggle>
   </div>
 
   <div class="label-group">
-    <div class="label"><span>Display font size</span> <br/>  {{data.fontSize}} px</div>
-    <mat-slider min="4" max="72" step="1" discrete>
+    <div class="label">
+      <span class="label-title">Display font size</span> <br/>  {{data.fontSize}} px
+    </div>
+    <mat-slider min="4" max="72" step="1" discrete class="label-item">
       <input matSliderThumb [(ngModel)]="data.fontSize" (change)="emitData()">
     </mat-slider>
   </div>
 
   <div class="label-group">
-    <div class="label"><span>Max header size</span><br/>  {{data.headerCap}} chars</div>
-    <mat-slider min="20" max="200" step="1" discrete>
-      <input matSliderThumb [(ngModel)]="data.headerCap" (change)="emitData()">
-    </mat-slider>
+    <div class="label">
+      <span class="label-title">Max header size</span><br/>
+        <span *ngIf="data.headerCap.isRange">
+          Soft cap: ≥ {{data.headerCap.range[0]}} chars <br/>
+        </span>
+      <span>Hard cap: ≥ {{data.headerCap.range[1]}} chars</span>
+    </div>
+    <app-toggleable-range-slider
+      class="label-item"
+      [min]="20"
+      [max]="150"
+      [step]="1"
+      [settings]="data.headerCap"
+      (settingsChange)="data.headerCap=$event; emitData()"></app-toggleable-range-slider>
   </div>
 
   <div class="label-group">
-    <div class="label"><span>Max content size</span> <br/> {{data.bodyCap}} chars</div>
-    <mat-slider min="20" max="200" step="1" discrete>
-      <input matSliderThumb [(ngModel)]="data.bodyCap" (change)="emitData()">
-    </mat-slider>
+    <div class="label">
+      <span class="label-title">Max content size</span> <br/>
+      Break line when ≥ {{data.bodyCap.range[1]}} chars
+    </div>
+    <app-toggleable-range-slider
+      class="label-item"
+      [min]="20"
+      [max]="150"
+      [step]="1"
+      [settings]="data.bodyCap"
+      (settingsChange)="data.bodyCap=$event; emitData()"></app-toggleable-range-slider>
   </div>
 </div>
 <div mat-dialog-actions>

--- a/src/app/editor-setting/editor-setting.dialog.ts
+++ b/src/app/editor-setting/editor-setting.dialog.ts
@@ -7,6 +7,8 @@ import { MatSliderModule } from '@angular/material/slider';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatButtonModule } from '@angular/material/button';
 import { SettingData, getDefaultSetting } from '../model/commit-storage';
+import { ToggleableRangeSliderComponent } from './toggleable-range-slider/toggleable-range-slider.component';
+import { NgIf } from '@angular/common';
 
 @Component({
   selector: 'app-editor-setting',
@@ -20,7 +22,9 @@ import { SettingData, getDefaultSetting } from '../model/commit-storage';
     MatCardModule,
     MatSliderModule,
     MatSlideToggleModule,
-    MatFormFieldModule
+    MatFormFieldModule,
+    NgIf,
+    ToggleableRangeSliderComponent
   ],
 })
 export class EditorSettingDialog {
@@ -28,11 +32,11 @@ export class EditorSettingDialog {
 
   constructor(
     public dialogRef: MatDialogRef<EditorSettingDialog>,
-    @Inject(MAT_DIALOG_DATA) public data: SettingData,
+    @Inject(MAT_DIALOG_DATA) public data: any,
   ) { }
 
-  emitData() {
-    this.contentChange.emit(this.data);
+  emitData(data: SettingData = this.data) {
+    this.contentChange.emit(data);
   }
 
   reset() {

--- a/src/app/editor-setting/toggleable-range-slider/toggleable-range-slider.component.css
+++ b/src/app/editor-setting/toggleable-range-slider/toggleable-range-slider.component.css
@@ -1,0 +1,13 @@
+.checkbox-margin {
+  margin: 10px 0;
+}
+
+.slider-container {
+  display: flex;
+  align-items: center;
+  width: 100%;
+}
+
+.slider {
+  width: 100%;
+}

--- a/src/app/editor-setting/toggleable-range-slider/toggleable-range-slider.component.html
+++ b/src/app/editor-setting/toggleable-range-slider/toggleable-range-slider.component.html
@@ -1,0 +1,18 @@
+<div class="slider-container">
+  <mat-slider [min]="min" [max]="max" [step]="step" discrete *ngIf="settings.isRange" class="slider">
+    <input matSliderStartThumb [(ngModel)]="settings.range[0]" (change)="emitData()">
+    <input matSliderEndThumb [(ngModel)]="settings.range[1]" (change)="emitData()">
+  </mat-slider>
+
+  <mat-slider [min]="min" [max]="max" [step]="step" discrete *ngIf="!settings.isRange" class="slider">
+    <input matSliderThumb [(ngModel)]="settings.range[1]" (change)="syncLowerBound();emitData()">
+  </mat-slider>
+
+  <mat-checkbox
+    *ngIf="settings.enableToggle"
+    class="checkbox-margin"
+    [(ngModel)]="settings.isRange"
+    matTooltip="Enable Warning"
+    (change)="emitData()">
+  </mat-checkbox>
+</div>

--- a/src/app/editor-setting/toggleable-range-slider/toggleable-range-slider.component.ts
+++ b/src/app/editor-setting/toggleable-range-slider/toggleable-range-slider.component.ts
@@ -1,0 +1,38 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatSliderModule } from '@angular/material/slider';
+
+import { WarningRange } from '../../model/commit-storage';
+
+@Component({
+  selector: 'app-toggleable-range-slider',
+  templateUrl: './toggleable-range-slider.component.html',
+  styleUrls: ['./toggleable-range-slider.component.css'],
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    MatCheckboxModule,
+    MatSliderModule,
+    MatTooltipModule,
+  ]
+})
+export class ToggleableRangeSliderComponent {
+  @Input() settings!: WarningRange;
+  @Input() min: number = 0;
+  @Input() max: number = 100;
+  @Input() step: number = 1;
+
+  @Output() settingsChange: EventEmitter<WarningRange> = new EventEmitter<WarningRange>();
+
+  emitData() {
+    this.settingsChange.emit(this.settings);
+  }
+
+  syncLowerBound() {
+    this.settings.range[0] = this.settings.range[1];
+  }
+}

--- a/src/app/editor/editor.component.css
+++ b/src/app/editor/editor.component.css
@@ -6,7 +6,6 @@
 }
 
 .card {
-  max-width: 1000px;
   width: 100%;
   height: 100%;
   padding: 5px;

--- a/src/app/fabs/setting-fab/setting-fab.component.css
+++ b/src/app/fabs/setting-fab/setting-fab.component.css
@@ -1,3 +1,7 @@
 button {
   margin: 10px;
 }
+
+.no-scroll-container {
+  overflow-y: hidden;
+}

--- a/src/app/fabs/setting-fab/setting-fab.component.ts
+++ b/src/app/fabs/setting-fab/setting-fab.component.ts
@@ -17,8 +17,9 @@ export class SettingFabComponent {
   constructor(public dialog: MatDialog) { }
 
   openSettingDialog() {
-    const dialogRef: MatDialogRef<EditorSettingDialog, SettingData> = this.dialog.open(EditorSettingDialog, {
-      data: this.editorSettings
+    const dialogRef: MatDialogRef<EditorSettingDialog, any> = this.dialog.open(EditorSettingDialog, {
+      data: this.editorSettings,
+      width: '50vw',
     });
 
     const subscription = dialogRef.componentInstance.contentChange.subscribe((data: SettingData) => {

--- a/src/app/fabs/warning-fab/warning-fab.component.html
+++ b/src/app/fabs/warning-fab/warning-fab.component.html
@@ -10,9 +10,15 @@
 <mat-menu #menu yPosition="above">
   <div class="menu-content">
     <button
+      extended
       *ngFor="let warning of warnings"
       (click)="openSnackBar(warning.detail); highlightLine(warning)"
       [matTooltip]="warning.detail"
-      mat-menu-item> Line {{warning.lineNum + 1}}</button>
+      mat-menu-item>
+      <mat-icon [color]="severityToIcon[warning.severity].color">
+        {{ severityToIcon[warning.severity].icon }}
+      </mat-icon>
+      Line {{warning.lineNum + 1}}
+    </button>
   </div>
 </mat-menu>

--- a/src/app/fabs/warning-fab/warning-fab.component.ts
+++ b/src/app/fabs/warning-fab/warning-fab.component.ts
@@ -2,12 +2,33 @@ import { Component, Input } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Warning } from '../../model/formatter.model'
 
+type IconDisplay = {
+  icon: string,
+  color: string,
+}
+
 @Component({
   selector: 'app-warning-fab',
   templateUrl: './warning-fab.component.html',
   styleUrls: ['./warning-fab.component.css'],
 })
 export class WarningFabComponent {
+
+  severityToIcon: { [key: string]: IconDisplay } = {
+    'low': {
+      icon: 'info',
+      color: 'primary',
+    },
+    'medium': {
+      icon: 'warning',
+      color: 'accent',
+    },
+    'high': {
+      icon: 'error',
+      color: 'warn',
+    },
+  }
+
   @Input() warnings?: Warning[] = [];
   textEditor?: HTMLTextAreaElement;
 

--- a/src/app/model/commit-storage.ts
+++ b/src/app/model/commit-storage.ts
@@ -1,17 +1,30 @@
 import { Formatter } from "./formatter.model";
 
+export type WarningRange = {
+  range: [number, number];
+  isRange: boolean;
+  enableToggle: boolean;
+};
 
 export interface SettingData {
-  headerCap: number;
-  bodyCap: number;
+  headerCap: WarningRange;
+  bodyCap: WarningRange;
   removeDoubleSpace: boolean;
   fontSize: number;
 };
 
 export const getDefaultSetting: () => SettingData = () => {
   return {
-    headerCap: 50,
-    bodyCap: 72,
+    headerCap: {
+      range: [50, 72],
+      isRange: true,
+      enableToggle: true,
+    },
+    bodyCap: {
+      range: [72, 72],
+      isRange: false,
+      enableToggle: false,
+    },
     removeDoubleSpace: true,
     fontSize: 16,
   };


### PR DESCRIPTION
All warnings are displayed in a similar manner even though some warnings are more severe than others.

To differentiate between the different types of warnings, a severity value is added to the warnings, and a custom label to differentiate between the different warnings.

Addition warnings where the commit subject exceeds 50 characters are also added to introduce more warning variety. Along with it, an additional toggle is added to allow the user to customize whether they need the warning or not.